### PR TITLE
Fler ändringar

### DIFF
--- a/G8-Mapp/Assets/Prefabs/StartPositionPrefab.prefab
+++ b/G8-Mapp/Assets/Prefabs/StartPositionPrefab.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3973116569632568922}
   - component: {fileID: 1845377500}
+  - component: {fileID: 1234519092186768165}
   m_Layer: 0
   m_Name: StartPositionPrefab
   m_TagString: StartPosition
@@ -84,3 +85,29 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!61 &1234519092186768165
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3973116569632568921}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1.029703, y: 1.029703}
+    newSize: {x: 1.029703, y: 1.029703}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1.029703, y: 1.029703}
+  m_EdgeRadius: 0

--- a/G8-Mapp/Assets/Scripts/BridgeColliderScript.cs
+++ b/G8-Mapp/Assets/Scripts/BridgeColliderScript.cs
@@ -6,6 +6,15 @@ public class BridgeColliderScript : ColliderScript
 {
     [SerializeField] private Sprite bridgeTakenOnceSprite;
 
+    new private void Start()
+    {
+        base.Start();
+        if (tileScript.GetType() != typeof(BridgeTile))
+        {
+            Debug.LogWarning("Varning, " + gameObject.name + "'s gridTile är inte av typen BridgeTile. Därmed kommer inte specifik BridgeTile-funktionalitet att fungera.");
+        }
+    }
+
     public void SetBridgeSpriteToStartSprite()
     {
         ChangeGridSprite(TileStartSprite);
@@ -20,7 +29,7 @@ public class BridgeColliderScript : ColliderScript
     {
         base.DisableTile();
         //Typkonvertering används här för att försäkra oss om att vi använder korsningsfunktionaliteten
-        BridgeTile bridgeTile = (BridgeTile)gridTile;
+        BridgeTile bridgeTile = (BridgeTile)tileScript;
         bridgeTile.SetCrossedOnceStatus(false);
         bridgeTile.SetTakenStatus(false);
     }
@@ -32,7 +41,8 @@ public class BridgeColliderScript : ColliderScript
 
     private void ResetBridgeTile()
     {
-        BridgeTile bridgeTile = (BridgeTile)gridTile;
+        //Typkonvertering används här för att försäkra oss om att vi använder korsningsfunktionaliteten
+        BridgeTile bridgeTile = (BridgeTile)tileScript;
         if (bridgeTile.GetTakenStatus())
         {
             bridgeTile.SetTakenStatus(false);

--- a/G8-Mapp/Assets/Scripts/ColliderScript.cs
+++ b/G8-Mapp/Assets/Scripts/ColliderScript.cs
@@ -11,7 +11,7 @@ public abstract class ColliderScript : MonoBehaviour
     protected BoxCollider2D boxCollider;
 
     [Header("Scripts")]
-    [SerializeField] protected GridTile gridTile;
+    [SerializeField] protected GridTile tileScript;
 
     [Header("Gameobjects")]
     [SerializeField] protected GameObject childObject;
@@ -66,7 +66,7 @@ public abstract class ColliderScript : MonoBehaviour
         spriteRenderer = gameObject.GetComponent<SpriteRenderer>();
         spriteRenderer.sprite = TileStartSprite;
         boxCollider = GetComponent<BoxCollider2D>();
-        gridTile = gameObject.GetComponentInChildren<GridTile>();
+        tileScript = gameObject.GetComponentInChildren<GridTile>();
     }
 
     protected void ChangeGridSprite(Sprite sprite)

--- a/G8-Mapp/Assets/Scripts/GridList.cs
+++ b/G8-Mapp/Assets/Scripts/GridList.cs
@@ -31,18 +31,9 @@ public class GridList : MonoBehaviour
                 gridList.Add(collision.gameObject);
             }
             else if (collision.gameObject.CompareTag("BridgeTile"))
-            {
-                BridgeTile bridgeTile = collision.gameObject.GetComponent<BridgeTile>();
-                if (!bridgeTile.GetTakenStatus())
-                {
-                    Debug.Log("Lägger till en bro i listan");
-                    gridList.Add(collision.gameObject);
-                }
-                else
-                {
-                    Debug.Log("Lägger till en tagen bro i listan");
-                    gridList.Add(collision.gameObject);
-                }
+            {   
+                //Broar ska alltid läggas till när det går
+                gridList.Add(collision.gameObject);
             }
         }
         

--- a/G8-Mapp/Assets/Scripts/SnakeMovement.cs
+++ b/G8-Mapp/Assets/Scripts/SnakeMovement.cs
@@ -204,6 +204,7 @@ public class SnakeMovement : MonoBehaviour
 
         Debug.DrawRay(mouseRay.origin, mouseRay.direction, Color.blue);
 
+        Debug.Log(mouseRay.direction);
         //Är riktningen ett nummer som är en multiplicering av våran riktningskonstant? (det vill säga en rät linje)
         bool directionIsMultiple = Mathf.RoundToInt(mouseRay.direction.x) % DIRECTION_ANGLE == 0 || Mathf.RoundToInt(mouseRay.direction.y) % DIRECTION_ANGLE == 0;
         return directionIsMultiple;
@@ -212,7 +213,7 @@ public class SnakeMovement : MonoBehaviour
     #region OnTrigger-funktioner
     private void OnTriggerEnter2D(Collider2D collision)
     {
-        if (collision.CompareTag("GridTile") || collision.CompareTag("BridgeTile"))
+        if (collision.CompareTag("GridTile") || collision.CompareTag("BridgeTile") || collision.CompareTag(startPosition.tag))
         {
             onTile = true;
         }

--- a/G8-Mapp/Assets/Scripts/TileColliderScript.cs
+++ b/G8-Mapp/Assets/Scripts/TileColliderScript.cs
@@ -14,14 +14,14 @@ public class TileColliderScript : ColliderScript
 
     private void ResetGridTile()
     {
-        gridTile.SetTakenStatus(false);
+        tileScript.SetTakenStatus(false);
         ChangeGridSprite(TileStartSprite);
     }
 
     public override void DisableTile()
     {
         base.DisableTile();
-        gridTile.SetTakenStatus(false);
+        tileScript.SetTakenStatus(false);
     }
 }
 


### PR DESCRIPTION
* StartPositionPrefab:
** Har nu en BoxCollider2D på sig med IsTrigger inställd. Detta förhindrar att ormen rör sig utanför den och fastnar utanför spelplanen.

* BridgeColliderScript: 
** Varnar nu i inspektorn om dess tileScript inte är av typen BridgeTile.

* ColliderScript: 
** gridTile-variabeln har nu bytt namn till tileScript. Det är mer generellt användbart.

* GridList: 
** Rensar onödig och repeterad kod från OnTriggerEnter2D. Det vill säga den delen som lägger till broar.

* SnakeMovement: 
** Skickar nu meddelanden om värdet på riktningen "IsDirectionStraight" i konsolen.

* TileColliderScript 
** Omfaktorerar namnet på gridTile efter ändring av variabelnamnet.